### PR TITLE
Create Makefile for protobuf

### DIFF
--- a/secondary/protobuf/Makefile
+++ b/secondary/protobuf/Makefile
@@ -1,0 +1,10 @@
+PROTOS = $(wildcard */*.proto)
+TARGET = $(PROTOS:.proto=.pb.go)
+GO_PACKAGE = $(subst ;,,$(lastword $(shell grep package $(1))))
+
+.PHONY: all clean
+all: $(TARGET)
+clean:
+	$(RM) $(TARGET)
+%.pb.go: %.proto
+	protoc --proto_path=$(dir $^) --go_out=$(dir $^) $(foreach protofile, $(filter $(dir $^)%, $(PROTOS)), --go_opt=M$(notdir $(protofile))="./;$(call GO_PACKAGE, $^)") $(notdir $^)


### PR DESCRIPTION
Creating a Makefile for protobuf which can generate the required *.pg.go files and is required in building secondary.