### PR TITLE
Having a new with param to indicate that the where expression is immutable

### DIFF
--- a/secondary/common/index.go
+++ b/secondary/common/index.go
@@ -223,6 +223,7 @@ type IndexDefn struct {
 	//PartitionKey is obsolete
 	PartitionKey           string     `json:"partitionKey,omitempty"`
 	WhereExpr              string     `json:"where,omitempty"`
+	WhereExprImmutable     bool       `json:"whereImmutable,omitempty"`
 	Desc                   []bool     `json:"desc,omitempty"`
 	Deferred               bool       `json:"deferred,omitempty"`
 	Immutable              bool       `json:"immutable,omitempty"`

--- a/secondary/protobuf/projector/index.go
+++ b/secondary/protobuf/projector/index.go
@@ -487,7 +487,7 @@ func (ie *IndexEvaluator) populateData(vbuuid uint64, m *mc.DcpEvent,
 				// for the given feed
 				processUpsertDel()
 			}
-		} else { // if WHERE is false, broadcast upsertdelete.
+		} else if !instn.GetWhereExprImmutable() { // if WHERE is false, broadcast upsertdelete.
 			// NOTE: downstream can use upsertdelete and immutable flag
 			// to optimize out back-index lookup.
 			processUpsertDel()


### PR DESCRIPTION
In order to avoir the update of index that are not concerned by its where clause when this one is immutable I proposed to have a new WITH param. This new param can be "where_expr_immutable" 

